### PR TITLE
Add mobile option, some typos

### DIFF
--- a/eccv.sty
+++ b/eccv.sty
@@ -24,6 +24,7 @@
 % "options" include
 %  * "review" for submitting a paper for review and
 %  * "final" for the camera ready (default).
+%  * "mobile" for camera ready on small-screen devices
 %  * "year=20??" allows to specify the conference year (default current year).
 %  * "ID=12345" allows to specify the paper ID (default `none').
 %
@@ -54,6 +55,9 @@
 \RequirePackage{amsmath}                 % Need AMS packages to bug fix 
 \RequirePackage{amssymb}                 %   line numbers in equations
 \RequirePackage{cite}                    % Sort citations
+\RequirePackage{xspace}  
+
+\usepackage[a4paper]{geometry}
 
 % Breaking lines for URLs in the bib
 \RequirePackage[hyphens]{url}
@@ -80,6 +84,7 @@
 
 \DeclareBoolOption{review}
 \DeclareComplementaryOption{final}{review}
+\DeclareBoolOption{mobile}
 \DeclareStringOption[\the\year]{year}
 \DeclareStringOption[none]{ID}
 \DeclareDefaultOption{\PackageWarning{eccv}{Unkown option `\CurrentOption'}}
@@ -216,7 +221,7 @@
   }
 
   % Crop the page for review version
-  \usepackage[width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm]{geometry}
+  \geometry{width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm}
 
   % Replace authors, institute, and running title with review placeholders
   \let\maketitleold\maketitle
@@ -227,8 +232,13 @@
                             \maketitleold}
 \fi
 
+\ifeccv@mobile
+  % Crop the page for mobile version
+  \geometry{width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm}
+\fi
+
 % Macro for ECCV year in main text
-\newcommand{\ECCVyear}{\eccv@year}
+\newcommand{\ECCVyear}{\eccv@year\xspace}
 \makeatother
 
 

--- a/eccv.sty
+++ b/eccv.sty
@@ -57,8 +57,6 @@
 \RequirePackage{cite}                    % Sort citations
 \RequirePackage{xspace}  
 
-\usepackage[a4paper]{geometry}
-
 % Breaking lines for URLs in the bib
 \RequirePackage[hyphens]{url}
 \Urlmuskip=0mu plus 1mu\relax
@@ -221,7 +219,7 @@
   }
 
   % Crop the page for review version
-  \geometry{width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm}
+  \RequirePackage[width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm]{geometry}
 
   % Replace authors, institute, and running title with review placeholders
   \let\maketitleold\maketitle
@@ -234,7 +232,7 @@
 
 \ifeccv@mobile
   % Crop the page for mobile version
-  \geometry{width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm}
+  \RequirePackage[width=122mm,left=12mm,paperwidth=146mm,height=193mm,top=12mm,paperheight=217mm]{geometry}
 \fi
 
 % Macro for ECCV year in main text

--- a/main.tex
+++ b/main.tex
@@ -405,7 +405,8 @@ It is cumbersome to have to use circumlocutions like ``the equation second from 
 All authors will benefit from reading Mermin's description of how to write mathematics:
 \url{http://www.ai.mit.edu/courses/6.899/papers/mermin.pdf}.
 
-Equations should be punctuated in the same way as ordinary text. 
+% No color equations in Springer publications.
+Equations should never be in color and should be punctuated in the same way as ordinary text.
 They should not be pasted in as figures.
 
 

--- a/main.tex
+++ b/main.tex
@@ -9,6 +9,10 @@
 % TODO FINAL: Un-comment the following line for the camera-ready version
 %\usepackage{eccv}
 
+% OPTIONAL: Un-comment the following line for a version which is easier to read
+% on small portrait-orientation screens (e.g. mobile phones, or beside other windows)
+%\usepackage[mobile]{eccv}
+
 
 % ---------------------------------------------------------------
 % Other packages
@@ -241,7 +245,7 @@ An example of an acceptable paper:
 If you are making a submission to another conference at the same time, which covers similar or overlapping material, you may need to refer to that submission in order to explain the differences, just as you would if you had previously published related work.
 In such cases, include the anonymized parallel submission~\cite{Authors14} as supplemental material and cite it as
 \begin{quote}
-  [1] Authors. ``The frobnicatable foo filter'', BMVS 2014 Submission ID 324, Supplied as supplemental material {\tt bmvc324.pdf}.
+  [1] Authors. ``The frobnicatable foo filter'', ECCV \ECCVyear Submission ID 1394, Supplied as supplemental material {\tt eccv1394.pdf}.
 \end{quote}
 
 Finally, you may feel you need to tell the reader that more details can be found elsewhere, and refer them to a technical report.
@@ -399,9 +403,9 @@ Just because you did not refer to it in the text does not mean some future reade
 It is cumbersome to have to use circumlocutions like ``the equation second from the top of page 3 column 1''.
 (Note that the ruler will not be present in the final copy, so is not an alternative to equation numbers).
 All authors will benefit from reading Mermin's description of how to write mathematics:
-\url{http://www.pamitc.org/documents/mermin.pdf}.
+\url{http://www.ai.mit.edu/courses/6.899/papers/mermin.pdf}.
 
-Equations should never be in color and should be punctuated in the same way as ordinary text. 
+Equations should be punctuated in the same way as ordinary text. 
 They should not be pasted in as figures.
 
 
@@ -478,7 +482,8 @@ The space after \eg, meaning ``for example'', should not be a sentence-ending sp
 So \eg is correct, {\em e.g.} is not.
 The provided \verb'\eg' macro takes care of this.
 
-When citing a multi-author paper, you may save space by using ``et alia'', shortened to ``\etal'' (not ``{\em et.\ al.}'' as ``{\em et}'' is a complete word).
+When citing a multi-author paper, you may save space by using ``et alia'', 
+shortened to ``\etal'' (not ``{\em et.\ al.}'' as ``{\em et\hskip 0.1em}'' is a complete word).
 If you use the \verb'\etal' macro provided, then you need not worry about double periods when used at the end of a sentence as in Alpher \etal.
 However, use it only when there are three or more authors.
 Thus, the following is correct:


### PR DESCRIPTION
A valuable feature of the ECCV one-page format is that it renders nicely on mobile phones or in a small window beside one's main window.  This PR adds an option to enable that for camera-ready as well as review version.

It also fixes a couple of spacing glitches and a broken link.